### PR TITLE
correct_geolocation.py: fix related to np.float depreciation

### DIFF
--- a/miaplpy/correct_geolocation.py
+++ b/miaplpy/correct_geolocation.py
@@ -57,7 +57,7 @@ def main(iargs=None):
 
     if status == 'run':
 
-        az_angle = np.deg2rad(np.float(atr['HEADING']))
+        az_angle = np.deg2rad(float(atr['HEADING']))
         inc_angle = np.deg2rad(readfile.read(inps.geometry_file, datasetName='incidenceAngle')[0])
 
         dem_error = readfile.read(inps.dem_error_file, datasetName='dem')[0]


### PR DESCRIPTION
np.float (and np.int) is not supported anymore by new versions of numpy